### PR TITLE
Corrected the calculate pulsewidth formula in servo.c

### DIFF
--- a/src/servo.c
+++ b/src/servo.c
@@ -49,7 +49,7 @@ esp_err_t set_angle_servo(int servo_id, unsigned int degree_of_rotation)
             degree_of_rotation = degree_of_rotation > SERVO_A_MAX_DEGREE ? SERVO_A_MAX_DEGREE : degree_of_rotation;
 
             uint32_t cal_pulsewidth = 0;
-            cal_pulsewidth = (SERVO_A_MIN_PULSEWIDTH + (((SERVO_A_MAX_PULSEWIDTH - SERVO_A_MIN_PULSEWIDTH) * (degree_of_rotation)) / (SERVO_A_MAX_DEGREE)));
+            cal_pulsewidth = (SERVO_A_MIN_PULSEWIDTH + 2 * (((SERVO_A_MAX_PULSEWIDTH - SERVO_A_MIN_PULSEWIDTH) * (degree_of_rotation)) / (SERVO_A_MAX_DEGREE)));
 
             esp_err_t err_A = mcpwm_set_duty_in_us(MCPWM_UNIT_0, MCPWM_TIMER_0, MCPWM_OPR_A, cal_pulsewidth);
             if (err_A == ESP_OK)
@@ -68,7 +68,7 @@ esp_err_t set_angle_servo(int servo_id, unsigned int degree_of_rotation)
             degree_of_rotation = degree_of_rotation > SERVO_B_MAX_DEGREE ? SERVO_B_MAX_DEGREE : degree_of_rotation;
 
             uint32_t cal_pulsewidth = 0;
-            cal_pulsewidth = (SERVO_B_MIN_PULSEWIDTH + (((SERVO_B_MAX_PULSEWIDTH - SERVO_B_MIN_PULSEWIDTH) * (degree_of_rotation)) / (SERVO_B_MAX_DEGREE)));
+            cal_pulsewidth = (SERVO_B_MIN_PULSEWIDTH + 2 * (((SERVO_B_MAX_PULSEWIDTH - SERVO_B_MIN_PULSEWIDTH) * (degree_of_rotation)) / (SERVO_B_MAX_DEGREE)));
 
             esp_err_t err_B = mcpwm_set_duty_in_us(MCPWM_UNIT_0, MCPWM_TIMER_0, MCPWM_OPR_B, cal_pulsewidth);
             if (err_B == ESP_OK)
@@ -87,7 +87,7 @@ esp_err_t set_angle_servo(int servo_id, unsigned int degree_of_rotation)
             degree_of_rotation = degree_of_rotation > SERVO_C_MAX_DEGREE ? SERVO_C_MAX_DEGREE : degree_of_rotation;
 
             uint32_t cal_pulsewidth = 0;
-            cal_pulsewidth = (SERVO_C_MIN_PULSEWIDTH + (((SERVO_C_MAX_PULSEWIDTH - SERVO_C_MIN_PULSEWIDTH) * (degree_of_rotation)) / (SERVO_C_MAX_DEGREE)));
+            cal_pulsewidth = (SERVO_C_MIN_PULSEWIDTH + 2 * (((SERVO_C_MAX_PULSEWIDTH - SERVO_C_MIN_PULSEWIDTH) * (degree_of_rotation)) / (SERVO_C_MAX_DEGREE)));
 
             esp_err_t err_C = mcpwm_set_duty_in_us(MCPWM_UNIT_0, MCPWM_TIMER_1, MCPWM_OPR_A, cal_pulsewidth);
             if (err_C == ESP_OK)


### PR DESCRIPTION
Current Pulsewidth formula:
https://github.com/SRA-VJTI/sra-board-component/blob/529cd97d415df88d2f0b54c820ee9f486f5e824d/src/servo.c#L52


Pulsewidth formula in ROS2.1:
    cal_pulsewidth_micro = (MICRO_SERVO_MIN_PULSEWIDTH + 2 * (((MICRO_SERVO_MAX_PULSEWIDTH - MICRO_SERVO_MIN_PULSEWIDTH) * (degree_of_rotation)) / (SERVO_MAX_DEGREE)));
    
{https://github.com/SRA-VJTI/ROS-Workshop-2.1/blob/421385332b833aa6e2deba377620c4152f8a4ee7/esp32_codes/components/ros_sra20/servo.c#L52}

I have made changes accordingly and tested the formula used in ROS2.1 in hardware.
It's working.