### PR TITLE
Updated mpu6050 i2c driver to use i2cdev library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(srcs "src/adc.c" "src/bar_graph.c" "src/switches.c" "src/lsa.c" "src/motor_driver.c" "src/mpu6050.c" "src/servo.c" "src/utils.c")
+set(srcs "src/i2cdev.c" "src/adc.c" "src/bar_graph.c" "src/switches.c" "src/lsa.c" "src/motor_driver.c" "src/mpu6050.c" "src/servo.c" "src/utils.c")
 
 idf_component_register(SRCS "${srcs}"
                        INCLUDE_DIRS "include"

--- a/Kconfig
+++ b/Kconfig
@@ -1,5 +1,23 @@
 menu "SRA Board Component Config"
 
+menu "I2C"
+
+config I2CDEV_TIMEOUT
+    int "I2C transaction timeout, milliseconds"
+    default 1000
+    range 100 5000
+    
+config I2CDEV_NOLOCK
+	bool "Disable the use of mutexes"
+	default n
+	help
+		Attention! After enabling this option, all I2C device
+		drivers will become non-thread safe. 
+		Use this option if you need to access your I2C devices
+		from interrupt handlers. 
+
+endmenu
+
 menu "Servo motor configuration"
 
 menu "Servo A"
@@ -75,5 +93,5 @@ config NUMBER_OF_SAMPLES
     default 64
     help
         sets the number of ADC samples to average to use with LSA
-        
+
 endmenu

--- a/include/esp_idf_lib_helpers.h
+++ b/include/esp_idf_lib_helpers.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2019 Tomoyuki Sakurai <y@trombik.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#if !defined(__ESP_IDF_LIB_HELPERS__H__)
+#define __ESP_IDF_LIB_HELPERS__H__
+
+/* XXX this header file does not need to include freertos/FreeRTOS.h.
+ * but without it, ESP8266 RTOS SDK does not include `sdkconfig.h` in correct
+ * order. as this header depends on sdkconfig.h, sdkconfig.h must be included
+ * first. however, the SDK includes this header first, then includes
+ * `sdkconfig.h` when freertos/FreeRTOS.h is not explicitly included. an
+ * evidence can be found in `build/${COMPONENT}/${COMPONENT}.d` in a failed
+ * build.
+ */
+#include <freertos/FreeRTOS.h>
+#include <esp_idf_version.h>
+
+#if !defined(ESP_IDF_VERSION) || !defined(ESP_IDF_VERSION_VAL)
+#error Unknown ESP-IDF/ESP8266 RTOS SDK version
+#endif
+
+/* Minimal supported version for ESP32, ESP32S2 */
+#define HELPER_ESP32_MIN_VER    ESP_IDF_VERSION_VAL(3, 3, 5)
+/* Minimal supported version for ESP8266 */
+#define HELPER_ESP8266_MIN_VER  ESP_IDF_VERSION_VAL(3, 3, 0)
+
+/* HELPER_TARGET_IS_ESP32
+ * 1 when the target is esp32
+ */
+#if defined(CONFIG_IDF_TARGET_ESP32) \
+        || defined(CONFIG_IDF_TARGET_ESP32S2) \
+        || defined(CONFIG_IDF_TARGET_ESP32S3) \
+        || defined(CONFIG_IDF_TARGET_ESP32C3)
+#define HELPER_TARGET_IS_ESP32     (1)
+#define HELPER_TARGET_IS_ESP8266   (0)
+
+/* HELPER_TARGET_IS_ESP8266
+ * 1 when the target is esp8266
+ */
+#elif defined(CONFIG_IDF_TARGET_ESP8266)
+#define HELPER_TARGET_IS_ESP32     (0)
+#define HELPER_TARGET_IS_ESP8266   (1)
+#else
+#error BUG: cannot determine the target
+#endif
+
+#if HELPER_TARGET_IS_ESP32 && ESP_IDF_VERSION < HELPER_ESP32_MIN_VER
+#error Unsupported ESP-IDF version. Please update!
+#endif
+
+#if HELPER_TARGET_IS_ESP8266 && ESP_IDF_VERSION < HELPER_ESP8266_MIN_VER
+#error Unsupported ESP8266 RTOS SDK version. Please update!
+#endif
+
+/* show the actual values for debugging */
+#if DEBUG
+#define VALUE_TO_STRING(x) #x
+#define VALUE(x) VALUE_TO_STRING(x)
+#define VAR_NAME_VALUE(var) #var "="  VALUE(var)
+#pragma message(VAR_NAME_VALUE(CONFIG_IDF_TARGET_ESP32C3))
+#pragma message(VAR_NAME_VALUE(CONFIG_IDF_TARGET_ESP32S2))
+#pragma message(VAR_NAME_VALUE(CONFIG_IDF_TARGET_ESP32))
+#pragma message(VAR_NAME_VALUE(CONFIG_IDF_TARGET_ESP8266))
+#pragma message(VAR_NAME_VALUE(ESP_IDF_VERSION_MAJOR))
+#endif
+
+#endif

--- a/include/i2cdev.h
+++ b/include/i2cdev.h
@@ -1,0 +1,226 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Ruslan V. Uss <unclerus@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * @file i2cdev.h
+ * @defgroup i2cdev i2cdev
+ * @{
+ *
+ * ESP-IDF I2C master thread-safe functions for communication with I2C slave
+ *
+ * Copyright (c) 2018 Ruslan V. Uss <unclerus@gmail.com>
+ *
+ * MIT Licensed as described in the file LICENSE
+ */
+#ifndef __I2CDEV_H__
+#define __I2CDEV_H__
+
+#include <driver/i2c.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+#include <esp_err.h>
+#include <esp_idf_lib_helpers.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if HELPER_TARGET_IS_ESP8266
+#define I2CDEV_MAX_STRETCH_TIME 0xffffffff
+#else
+#include <soc/i2c_reg.h>
+#ifdef I2C_TIME_OUT_REG_V
+#define I2CDEV_MAX_STRETCH_TIME I2C_TIME_OUT_REG_V
+#else
+#define I2CDEV_MAX_STRETCH_TIME 0x00ffffff
+#endif
+#endif
+
+/**
+ * I2C device descriptor
+ */
+typedef struct
+{
+    i2c_port_t port;         //!< I2C port number
+    i2c_config_t cfg;        //!< I2C driver configuration
+    uint8_t addr;            //!< Unshifted address
+    SemaphoreHandle_t mutex; //!< Device mutex
+    uint32_t timeout_ticks;  /*!< HW I2C bus timeout (stretch time), in ticks. 80MHz APB clock
+                                  ticks for ESP-IDF, CPU ticks for ESP8266.
+                                  When this value is 0, I2CDEV_MAX_STRETCH_TIME will be used */
+} i2c_dev_t;
+
+/**
+ * @brief Init library
+ *
+ * The function must be called before any other
+ * functions of this library.
+ *
+ * @return ESP_OK on success
+ */
+esp_err_t i2cdev_init();
+
+/**
+ * @brief Finish work with library
+ *
+ * Uninstall i2c drivers.
+ *
+ * @return ESP_OK on success
+ */
+esp_err_t i2cdev_done();
+
+/**
+ * @brief Create mutex for device descriptor
+ *
+ * This function does nothing if option CONFIG_I2CDEV_NOLOCK is enabled.
+ *
+ * @param dev Device descriptor
+ * @return ESP_OK on success
+ */
+esp_err_t i2c_dev_create_mutex(i2c_dev_t *dev);
+
+/**
+ * @brief Delete mutex for device descriptor
+ *
+ * This function does nothing if option CONFIG_I2CDEV_NOLOCK is enabled.
+ *
+ * @param dev Device descriptor
+ * @return ESP_OK on success
+ */
+esp_err_t i2c_dev_delete_mutex(i2c_dev_t *dev);
+
+/**
+ * @brief Take device mutex
+ *
+ * This function does nothing if option CONFIG_I2CDEV_NOLOCK is enabled.
+ *
+ * @param dev Device descriptor
+ * @return ESP_OK on success
+ */
+esp_err_t i2c_dev_take_mutex(i2c_dev_t *dev);
+
+/**
+ * @brief Give device mutex
+ *
+ * This function does nothing if option CONFIG_I2CDEV_NOLOCK is enabled.
+ *
+ * @param dev Device descriptor
+ * @return ESP_OK on success
+ */
+esp_err_t i2c_dev_give_mutex(i2c_dev_t *dev);
+
+/**
+ * @brief Read from slave device
+ *
+ * Issue a send operation of \p out_data register address, followed by reading \p in_size bytes
+ * from slave into \p in_data .
+ * Function is thread-safe.
+ *
+ * @param dev Device descriptor
+ * @param out_data Pointer to data to send if non-null
+ * @param out_size Size of data to send
+ * @param[out] in_data Pointer to input data buffer
+ * @param in_size Number of byte to read
+ * @return ESP_OK on success
+ */
+esp_err_t i2c_dev_read(const i2c_dev_t *dev, const void *out_data,
+        size_t out_size, void *in_data, size_t in_size);
+
+/**
+ * @brief Write to slave device
+ *
+ * Write \p out_size bytes from \p out_data to slave into \p out_reg register address.
+ * Function is thread-safe.
+ *
+ * @param dev Device descriptor
+ * @param out_reg Pointer to register address to send if non-null
+ * @param out_reg_size Size of register address
+ * @param out_data Pointer to data to send
+ * @param out_size Size of data to send
+ * @return ESP_OK on success
+ */
+esp_err_t i2c_dev_write(const i2c_dev_t *dev, const void *out_reg,
+        size_t out_reg_size, const void *out_data, size_t out_size);
+
+/**
+ * @brief Read from register with an 8-bit address
+ *
+ * Shortcut to ::i2c_dev_read().
+ *
+ * @param dev Device descriptor
+ * @param reg Register address
+ * @param[out] in_data Pointer to input data buffer
+ * @param in_size Number of byte to read
+ * @return ESP_OK on success
+ */
+esp_err_t i2c_dev_read_reg(const i2c_dev_t *dev, uint8_t reg,
+        void *in_data, size_t in_size);
+
+/**
+ * @brief Write to register with an 8-bit address
+ *
+ * Shortcut to ::i2c_dev_write().
+ *
+ * @param dev Device descriptor
+ * @param reg Register address
+ * @param out_data Pointer to data to send
+ * @param out_size Size of data to send
+ * @return ESP_OK on success
+ */
+esp_err_t i2c_dev_write_reg(const i2c_dev_t *dev, uint8_t reg,
+        const void *out_data, size_t out_size);
+
+#define I2C_DEV_TAKE_MUTEX(dev) do { \
+        esp_err_t __ = i2c_dev_take_mutex(dev); \
+        if (__ != ESP_OK) return __;\
+    } while (0)
+
+#define I2C_DEV_GIVE_MUTEX(dev) do { \
+        esp_err_t __ = i2c_dev_give_mutex(dev); \
+        if (__ != ESP_OK) return __;\
+    } while (0)
+
+#define I2C_DEV_CHECK(dev, X) do { \
+        esp_err_t ___ = X; \
+        if (___ != ESP_OK) { \
+            I2C_DEV_GIVE_MUTEX(dev); \
+            return ___; \
+        } \
+    } while (0)
+
+#define I2C_DEV_CHECK_LOGE(dev, X, msg, ...) do { \
+        esp_err_t ___ = X; \
+        if (___ != ESP_OK) { \
+            I2C_DEV_GIVE_MUTEX(dev); \
+            ESP_LOGE(TAG, msg, ## __VA_ARGS__); \
+            return ___; \
+        } \
+    } while (0)
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/
+
+#endif /* __I2CDEV_H__ */

--- a/include/mpu6050.h
+++ b/include/mpu6050.h
@@ -49,9 +49,18 @@
 #define I2C_MASTER_RX_BUF_DISABLE 0   /*!< I2C master do not need buffer */
 #define I2C_MASTER_FREQ_HZ 100000     /*!< I2C master clock frequency */
 
+#define MPU6050_RA_PWR_MGMT_1 0x6B
+#define MPU6050_CLOCK_PLL_XGYRO 0x01
+
+#define MPU6050_RA_GYRO_CONFIG 0x1B
+#define MPU6050_GYRO_FS_250 0x00
+
+#define MPU6050_RA_ACCEL_CONFIG 0x1C
+#define MPU6050_ACCEL_FS_2 0x00
+
 #define MPU6050_ADDR 0x68   /*!< slave address for mpu6050 sensor */
-#define ACCE_START_ADD 0x3B /*!< accelerometer start address */
-#define GYRO_START_ADD 0x43 /*!< gyroscope start address */
+#define ACCE_START_ADDR 0x3B /*!< accelerometer start address */
+#define GYRO_START_ADDR 0x43 /*!< gyroscope start address */
 
 #define WRITE_BIT I2C_MASTER_WRITE /*!< I2C master write */
 #define READ_BIT I2C_MASTER_READ   /*!< I2C master read */

--- a/src/i2cdev.c
+++ b/src/i2cdev.c
@@ -1,0 +1,304 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Ruslan V. Uss <unclerus@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * @file i2cdev.c
+ *
+ * ESP-IDF I2C master thread-safe functions for communication with I2C slave
+ *
+ * Copyright (c) 2018 Ruslan V. Uss <unclerus@gmail.com>
+ *
+ * MIT Licensed as described in the file LICENSE
+ */
+#include <string.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <esp_log.h>
+#include "i2cdev.h"
+
+static const char *TAG = "i2cdev";
+
+typedef struct {
+    SemaphoreHandle_t lock;
+    i2c_config_t config;
+    bool installed;
+} i2c_port_state_t;
+
+static i2c_port_state_t states[I2C_NUM_MAX];
+
+#if CONFIG_I2CDEV_NOLOCK
+#define SEMAPHORE_TAKE(port)
+#else
+#define SEMAPHORE_TAKE(port) do { \
+        if (!xSemaphoreTake(states[port].lock, pdMS_TO_TICKS(CONFIG_I2CDEV_TIMEOUT))) \
+        { \
+            ESP_LOGE(TAG, "Could not take port mutex %d", port); \
+            return ESP_ERR_TIMEOUT; \
+        } \
+        } while (0)
+#endif
+
+#if CONFIG_I2CDEV_NOLOCK
+#define SEMAPHORE_GIVE(port)
+#else
+#define SEMAPHORE_GIVE(port) do { \
+        if (!xSemaphoreGive(states[port].lock)) \
+        { \
+            ESP_LOGE(TAG, "Could not give port mutex %d", port); \
+            return ESP_FAIL; \
+        } \
+        } while (0)
+#endif
+
+esp_err_t i2cdev_init()
+{
+    memset(states, 0, sizeof(states));
+
+#if !CONFIG_I2CDEV_NOLOCK
+    for (int i = 0; i < I2C_NUM_MAX; i++)
+    {
+        states[i].lock = xSemaphoreCreateMutex();
+        if (!states[i].lock)
+        {
+            ESP_LOGE(TAG, "Could not create port mutex %d", i);
+            return ESP_FAIL;
+        }
+    }
+#endif
+
+    return ESP_OK;
+}
+
+esp_err_t i2cdev_done()
+{
+    for (int i = 0; i < I2C_NUM_MAX; i++)
+    {
+        if (!states[i].lock) continue;
+
+        if (states[i].installed)
+        {
+            SEMAPHORE_TAKE(i);
+            i2c_driver_delete(i);
+            states[i].installed = false;
+            SEMAPHORE_GIVE(i);
+        }
+#if !CONFIG_I2CDEV_NOLOCK
+        vSemaphoreDelete(states[i].lock);
+#endif
+        states[i].lock = NULL;
+    }
+    return ESP_OK;
+}
+
+esp_err_t i2c_dev_create_mutex(i2c_dev_t *dev)
+{
+#if !CONFIG_I2CDEV_NOLOCK
+    if (!dev) return ESP_ERR_INVALID_ARG;
+
+    ESP_LOGV(TAG, "[0x%02x at %d] creating mutex", dev->addr, dev->port);
+
+    dev->mutex = xSemaphoreCreateMutex();
+    if (!dev->mutex)
+    {
+        ESP_LOGE(TAG, "[0x%02x at %d] Could not create device mutex", dev->addr, dev->port);
+        return ESP_FAIL;
+    }
+#endif
+
+    return ESP_OK;
+}
+
+esp_err_t i2c_dev_delete_mutex(i2c_dev_t *dev)
+{
+#if !CONFIG_I2CDEV_NOLOCK
+    if (!dev) return ESP_ERR_INVALID_ARG;
+
+    ESP_LOGV(TAG, "[0x%02x at %d] deleting mutex", dev->addr, dev->port);
+
+    vSemaphoreDelete(dev->mutex);
+#endif
+    return ESP_OK;
+}
+
+esp_err_t i2c_dev_take_mutex(i2c_dev_t *dev)
+{
+#if !CONFIG_I2CDEV_NOLOCK
+    if (!dev) return ESP_ERR_INVALID_ARG;
+
+    ESP_LOGV(TAG, "[0x%02x at %d] taking mutex", dev->addr, dev->port);
+
+    if (!xSemaphoreTake(dev->mutex, pdMS_TO_TICKS(CONFIG_I2CDEV_TIMEOUT)))
+    {
+        ESP_LOGE(TAG, "[0x%02x at %d] Could not take device mutex", dev->addr, dev->port);
+        return ESP_ERR_TIMEOUT;
+    }
+#endif
+    return ESP_OK;
+}
+
+esp_err_t i2c_dev_give_mutex(i2c_dev_t *dev)
+{
+#if !CONFIG_I2CDEV_NOLOCK
+    if (!dev) return ESP_ERR_INVALID_ARG;
+
+    ESP_LOGV(TAG, "[0x%02x at %d] giving mutex", dev->addr, dev->port);
+
+    if (!xSemaphoreGive(dev->mutex))
+    {
+        ESP_LOGE(TAG, "[0x%02x at %d] Could not give device mutex", dev->addr, dev->port);
+        return ESP_FAIL;
+    }
+#endif
+    return ESP_OK;
+}
+
+inline static bool cfg_equal(const i2c_config_t *a, const i2c_config_t *b)
+{
+    return a->scl_io_num == b->scl_io_num
+        && a->sda_io_num == b->sda_io_num
+#if HELPER_TARGET_IS_ESP32
+        && a->master.clk_speed == b->master.clk_speed
+#elif HELPER_TARGET_IS_ESP8266
+        && a->clk_stretch_tick == b->clk_stretch_tick
+#endif
+        && a->scl_pullup_en == b->scl_pullup_en
+        && a->sda_pullup_en == b->sda_pullup_en;
+}
+
+static esp_err_t i2c_setup_port(const i2c_dev_t *dev)
+{
+    if (dev->port >= I2C_NUM_MAX) return ESP_ERR_INVALID_ARG;
+
+    esp_err_t res;
+    if (!cfg_equal(&dev->cfg, &states[dev->port].config))
+    {
+        ESP_LOGD(TAG, "Reconfiguring I2C driver on port %d", dev->port);
+        i2c_config_t temp;
+        memcpy(&temp, &dev->cfg, sizeof(i2c_config_t));
+        temp.mode = I2C_MODE_MASTER;
+
+        // Driver reinstallation
+        if (states[dev->port].installed)
+            i2c_driver_delete(dev->port);
+#if HELPER_TARGET_IS_ESP32
+        if ((res = i2c_param_config(dev->port, &temp)) != ESP_OK)
+            return res;
+        if ((res = i2c_driver_install(dev->port, temp.mode, 0, 0, 0)) != ESP_OK)
+            return res;
+#endif
+#if HELPER_TARGET_IS_ESP8266
+        // Clock Stretch time, depending on CPU frequency
+        temp.clk_stretch_tick = dev->timeout_ticks ? dev->timeout_ticks : I2CDEV_MAX_STRETCH_TIME;
+        if ((res = i2c_driver_install(dev->port, temp.mode)) != ESP_OK)
+            return res;
+        if ((res = i2c_param_config(dev->port, &temp)) != ESP_OK)
+            return res;
+#endif
+        states[dev->port].installed = true;
+
+        memcpy(&states[dev->port].config, &temp, sizeof(i2c_config_t));
+        ESP_LOGD(TAG, "I2C driver successfully reconfigured on port %d", dev->port);
+    }
+#if HELPER_TARGET_IS_ESP32
+    int t;
+    if ((res = i2c_get_timeout(dev->port, &t)) != ESP_OK)
+        return res;
+    // Timeout cannot be 0
+    uint32_t ticks = dev->timeout_ticks ? dev->timeout_ticks : I2CDEV_MAX_STRETCH_TIME;
+    if ((ticks != t) && (res = i2c_set_timeout(dev->port, ticks)) != ESP_OK)
+        return res;
+    ESP_LOGD(TAG, "Timeout: ticks = %d (%d usec) on port %d", dev->timeout_ticks, dev->timeout_ticks / 80, dev->port);
+#endif
+
+    return ESP_OK;
+}
+
+esp_err_t i2c_dev_read(const i2c_dev_t *dev, const void *out_data, size_t out_size, void *in_data, size_t in_size)
+{
+    if (!dev || !in_data || !in_size) return ESP_ERR_INVALID_ARG;
+
+    SEMAPHORE_TAKE(dev->port);
+
+    esp_err_t res = i2c_setup_port(dev);
+    if (res == ESP_OK)
+    {
+        i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+        if (out_data && out_size)
+        {
+            i2c_master_start(cmd);
+            i2c_master_write_byte(cmd, dev->addr << 1, true);
+            i2c_master_write(cmd, (void *)out_data, out_size, true);
+        }
+        i2c_master_start(cmd);
+        i2c_master_write_byte(cmd, (dev->addr << 1) | 1, true);
+        i2c_master_read(cmd, in_data, in_size, I2C_MASTER_LAST_NACK);
+        i2c_master_stop(cmd);
+
+        res = i2c_master_cmd_begin(dev->port, cmd, pdMS_TO_TICKS(CONFIG_I2CDEV_TIMEOUT));
+        if (res != ESP_OK)
+            ESP_LOGE(TAG, "Could not read from device [0x%02x at %d]: %d (%s)", dev->addr, dev->port, res, esp_err_to_name(res));
+
+        i2c_cmd_link_delete(cmd);
+    }
+
+    SEMAPHORE_GIVE(dev->port);
+    return res;
+}
+
+esp_err_t i2c_dev_write(const i2c_dev_t *dev, const void *out_reg, size_t out_reg_size, const void *out_data, size_t out_size)
+{
+    if (!dev || !out_data || !out_size) return ESP_ERR_INVALID_ARG;
+
+    SEMAPHORE_TAKE(dev->port);
+
+    esp_err_t res = i2c_setup_port(dev);
+    if (res == ESP_OK)
+    {
+        i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+        i2c_master_start(cmd);
+        i2c_master_write_byte(cmd, dev->addr << 1, true);
+        if (out_reg && out_reg_size)
+            i2c_master_write(cmd, (void *)out_reg, out_reg_size, true);
+        i2c_master_write(cmd, (void *)out_data, out_size, true);
+        i2c_master_stop(cmd);
+        res = i2c_master_cmd_begin(dev->port, cmd, pdMS_TO_TICKS(CONFIG_I2CDEV_TIMEOUT));
+        if (res != ESP_OK)
+            ESP_LOGE(TAG, "Could not write to device [0x%02x at %d]: %d (%s)", dev->addr, dev->port, res, esp_err_to_name(res));
+        i2c_cmd_link_delete(cmd);
+    }
+
+    SEMAPHORE_GIVE(dev->port);
+    return res;
+}
+
+esp_err_t i2c_dev_read_reg(const i2c_dev_t *dev, uint8_t reg,
+        void *in_data, size_t in_size)
+{
+    return i2c_dev_read(dev, &reg, 1, in_data, in_size);
+}
+
+esp_err_t i2c_dev_write_reg(const i2c_dev_t *dev, uint8_t reg,
+        const void *out_data, size_t out_size)
+{
+    return i2c_dev_write(dev, &reg, 1, out_data, out_size);
+}


### PR DESCRIPTION
It was observed that using esp-idf's inbuilt i2c driver caused issue due to it being single threaded. Updated the driver code to use i2cdev which is a threadsafe i2c library.

@gautam-dev-maker Please get this tested and let me know if it solves the issue and works fine.

