### PR TITLE
Add LSA calibration

### DIFF
--- a/include/lsa.h
+++ b/include/lsa.h
@@ -63,4 +63,6 @@ esp_err_t enable_line_sensor();
 **/
 line_sensor_array read_line_sensor();
 
+void calibrate(int *black_margin, int *white_margin);
+
 #endif

--- a/src/lsa.c
+++ b/src/lsa.c
@@ -63,12 +63,12 @@ void calibrate(int *black_margin, int *white_margin)
     int Min = 4095;
  
     line_sensor_array current_line_sensor_readings;
-    for (int i = 0; i < 4; i++)
+    for (int i = 0; i < 5; i++)
     {
         current_line_sensor_readings.adc_reading[i] = 0;
     }
  
-    for (int j = 0; j < 4; j++)
+    for (int j = 0; j < 5; j++)
     {
         current_line_sensor_readings.adc_reading[j] = read_adc(line_sensor_pins[j]);
         if (current_line_sensor_readings.adc_reading[j] > Max)

--- a/src/lsa.c
+++ b/src/lsa.c
@@ -56,3 +56,31 @@ line_sensor_array read_line_sensor()
 
     return line_sensor_readings;
 }
+
+void calibrate(int *black_margin, int *white_margin)
+{
+    int Max = 0;
+    int Min = 4095;
+ 
+    line_sensor_array current_line_sensor_readings;
+    for (int i = 0; i < 4; i++)
+    {
+        current_line_sensor_readings.adc_reading[i] = 0;
+    }
+ 
+    for (int j = 0; j < 4; j++)
+    {
+        current_line_sensor_readings.adc_reading[j] = read_adc(line_sensor_pins[j]);
+        if (current_line_sensor_readings.adc_reading[j] > Max)
+        {
+            Max = current_line_sensor_readings.adc_reading[j];
+        }
+        if (current_line_sensor_readings.adc_reading[j] < Min)
+        {
+            Min = current_line_sensor_readings.adc_reading[j];
+        }
+    }
+ 
+    *black_margin = Max;
+    *white_margin = Min;
+}


### PR DESCRIPTION
This PR adds the calibration for line sensor readings during the initial phase of the run.The calibrated readings gives us the black and white margins when the bot is placed on the maze/flex rather than passing hard-coded margins for different factors.This method helps in increasing precision for getting the accurate lsa readings when lighting conditions and mazes are varied.