### PR TITLE
Update ESP-IDF version from v4.2 to v4.4

### DIFF
--- a/.github/workflows/test-build-app.yaml
+++ b/.github/workflows/test-build-app.yaml
@@ -6,7 +6,7 @@ jobs:
     name: Test Build of component
     runs-on: ubuntu-latest
     container:
-      image: espressif/idf:release-v4.1
+      image: espressif/idf:release-v4.4
     strategy:
       matrix:
         test-apps: [bar_graph, lsa, motor_driver_normal, motor_driver_parallel, mpu6050, servos, switches, oled]

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ SRA ESP-IDF component provides an abstraction
 
 Toolchain & Supported SDK
 
-* [ESP-IDF v4.2-release](https://github.com/espressif/esp-idf/tree/release/v4.2)
+* [ESP-IDF v4.4-release](https://github.com/espressif/esp-idf/tree/release/v4.4)
 
 Docs
 
@@ -82,7 +82,7 @@ Docs
 ## Getting Started
 
 * Hardware Required : [SRA Development Board](https://github.com/SRA-VJTI/sra-board-hardware-design)
-* Recommended ESP-IDF [v4.2-release](https://github.com/espressif/esp-idf/tree/release/v4.2) .
+* Recommended ESP-IDF [v4.4-release](https://github.com/espressif/esp-idf/tree/release/v4.4) .
 
 _Refer [espressif-docs](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/get-started/) for intallation guide_
 


### PR DESCRIPTION
* This PR updates the ESP-IDF version used for inspecting all the codes by making adjustments to the CI/CD pipeline.
* README has also been updated with respect to ESP-IDF version.
