### PR TITLE
Set the clk_flags field to default configuration in the i2c configura…

### DIFF
--- a/src/u8g2_esp32_hal.c
+++ b/src/u8g2_esp32_hal.c
@@ -149,6 +149,7 @@ uint8_t u8g2_esp32_i2c_byte_cb(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void 
 		conf.scl_pullup_en = GPIO_PULLUP_ENABLE;
 		ESP_LOGI(TAG, "clk_speed %d", I2C_MASTER_OLED_FREQ_HZ);
 		conf.master.clk_speed = I2C_MASTER_OLED_FREQ_HZ;
+		conf.clk_flags = I2C_SCLK_SRC_FLAG_FOR_NOMAL;
 		ESP_LOGI(TAG, "i2c_param_config %d", conf.mode);
 		ESP_ERROR_CHECK(i2c_param_config(I2C_MASTER_OLED_NUM, &conf));
 		ESP_LOGI(TAG, "i2c_driver_install %d", I2C_MASTER_OLED_NUM);


### PR DESCRIPTION
…tion

The struct i2c_config_t now has a new field called clk_flags in the most recent stable version of the ESP-IDF,  ESP-IDF v4.4.2-dirty When self-balancing and MPU code are flashed, the i2c configuration fails because the field is not initialized in the present code, which results in the ESP32 rebooting.