### PR TITLE
Remove redundant global mutex declaration in I2C peripherals

### DIFF
--- a/src/i2cdev.c
+++ b/src/i2cdev.c
@@ -45,7 +45,6 @@ typedef struct {
 } i2c_port_state_t;
 
 static i2c_port_state_t states[I2C_NUM_MAX];
-SemaphoreHandle_t mutex = NULL;
 static bool i2c_initialised = false;
 
 #if CONFIG_I2CDEV_NOLOCK

--- a/src/lvgl_helpers.c
+++ b/src/lvgl_helpers.c
@@ -158,22 +158,7 @@ bool lvgl_i2c_driver_init(int sda_pin, int scl_pin, int speed_hz)
     ssd1306_dev_t.cfg.scl_pullup_en = GPIO_PULLUP_ENABLE;
     ssd1306_dev_t.cfg.master.clk_speed = OLED_IIC_FREQ_HZ;
 
-    // return i2c_dev_create_mutex(&ssd1306_dev_t);
-    if (mutex == NULL)
-    {
-        esp_err_t err = i2c_dev_create_mutex(&ssd1306_dev_t);
-        if (err == ESP_OK)
-        {
-            mutex = ssd1306_dev_t.mutex;
-        }
-        return err;
-    }
-    else
-    {
-        ssd1306_dev_t.mutex = mutex;
-        return ESP_OK;
-    }
-
+    return i2c_dev_create_mutex(&ssd1306_dev_t);
 }
 
 /**********************

--- a/src/mpu6050.c
+++ b/src/mpu6050.c
@@ -40,20 +40,7 @@ esp_err_t i2c_master_init(void)
     mpu6050_dev_t.cfg.scl_io_num = I2C_MASTER_SCL_IO;
     mpu6050_dev_t.cfg.master.clk_speed = I2C_MASTER_FREQ_HZ;
 
-    if (mutex == NULL)
-    {
-        esp_err_t err = i2c_dev_create_mutex(&mpu6050_dev_t);
-        if (err == ESP_OK)
-        {
-            mutex = mpu6050_dev_t.mutex;
-        }
-        return err;
-    }
-    else
-    {
-        mpu6050_dev_t.mutex = mutex;
-        return ESP_OK;
-    }
+    return i2c_dev_create_mutex(&mpu6050_dev_t);
 }
 
 // Initialise and power ON, MPU6050


### PR DESCRIPTION
Since `i2c_port_state_t states[I2C_NUM_MAX];` acts as the global mutex for each peripherals, there is no need for another global mutex variable. This PR removes the global mutex variable.