### PR TITLE
bugfix: Swapped the I2C SCL and SDA in `include/pin_defs.h`

### DIFF
--- a/include/pin_defs.h
+++ b/include/pin_defs.h
@@ -51,8 +51,8 @@
 
 #ifdef CONFIG_ENABLE_OLED
 //////// oled ////////
-#define OLED_SDA 22
-#define OLED_SCL 21
+#define OLED_SCL 22
+#define OLED_SDA 21
 #endif
 
 //////// bar graph //////////


### PR DESCRIPTION
In `include/pin_defs.h`, changed the following:
```c
//////// mpu //////
#define MPU6050_INT 23
#define MPU6050_SDA 22
#define MPU6050_SCL 21

/////////////////////////////

#ifdef CONFIG_ENABLE_OLED
//////// oled ////////
#define OLED_SDA 22
#define OLED_SCL 21
#endif
```
to
```c
//////// mpu //////
#define MPU6050_INT 23
#define MPU6050_SCL 22
#define MPU6050_SDA 21

/////////////////////////////

#ifdef CONFIG_ENABLE_OLED
//////// oled ////////
#define OLED_SCL 22
#define OLED_SDA 21
#endif
```